### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -7,7 +7,7 @@
         "PerlMongers::Hannover" : "lib/PerlMongers/Hannover.pm"
     },
     "authors" : "Paul Cochrane",
-    "license" : "http://www.perlfoundation.org/artistic_license_2_0",
+    "license" : "Artistic-2.0",
     "depends" : [ "IO::Capture::Simple" ],
     "test-depends" : [ "Test::META" ],
     "source-url" : "git://github.com/paultcochrane/Perl6Mongers-Hannover.git"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license